### PR TITLE
Fix tests for jax-toggle

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -62,7 +62,7 @@ jobs:
     - name: Run tests (pytest)
       shell: bash -l {0}
       run: |
-        pytest -v --cov=$PACKAGE --cov-report=xml --color=yes --doctest-modules $PACKAGE/
+        pytest -v --cov=$PACKAGE --cov-report=xml --color=yes --doctest-modules --doctest-ignore-import-errors $PACKAGE/
 
     - name: Run examples
       shell: bash -l {0}

--- a/pymbar/mbar_solvers/jax_solver.py
+++ b/pymbar/mbar_solvers/jax_solver.py
@@ -3,14 +3,17 @@
 import logging
 from functools import wraps
 
-from jax.config import config
+try:
+    from jax.config import config
 
-import jax.numpy as jnp
-from jax.numpy.linalg import lstsq
-import jax.scipy.optimize
-from jax.scipy.special import logsumexp
+    import jax.numpy as jnp
+    from jax.numpy.linalg import lstsq
+    import jax.scipy.optimize
+    from jax.scipy.special import logsumexp
 
-from jax import jit
+    from jax import jit
+except ImportError:
+    raise ImportError("JAX not found!")
 
 from pymbar.mbar_solvers.mbar_solver import MBARSolver
 


### PR DESCRIPTION
Fix pytest doctest trying to import everything and let it skip (had t…o go into source code to find this flag)

Fix lint complaining about jax import on no-jax systems by wrapping JAX and raising appropriately